### PR TITLE
Bump node-sass from 4.11.0 to 4.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "node-sass": "^4.11.0"
+    "node-sass": "^4.14.1"
   }
 }


### PR DESCRIPTION
Just ran into problem when trying to npm install.

node-sass 4.11.0 only supports Nodejs up to version 11
node-sass 4.14.1 will support Nodejs up to version 14.

Can still npm install and run project after change to dependency.