### PR TITLE
Provide a guideline for the node version on which application can be built

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
   "eslintConfig": {
     "extends": "react-app"
   },
+
+  "engines": {
+    "node": ">=10.0.0 <12"
+  },
   "browserslist": [
     ">0.2%",
     "not dead",


### PR DESCRIPTION
As part of taking this course on Front End Masters, I had difficulty with installing the application locally. I kept getting errors around 

`Error: Node Sass does not yet support your current environment: OS X 64-bit with Unsupported runtime (72)`

I finally isolated it out to Node Sass just not  having or supporting the architecture. I went from Node 16.x.x all the way to Node 10.x.x and that is where I was actually able to get the application to install node-sass and work. It took a bit of my time so I wanted to raise the PR and perhaps get your opinion to see if it's possible that the Node Version actually is a limitation for running the application. If so perhaps this PR can help other individuals coming to the course early on when they install.

